### PR TITLE
add new method to get association from commitee code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![js-semistandard-style](https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square)](https://github.com/Flet/semistandard)
 [![travis-ci](https://travis-ci.org/bb-ffbb/bbffbb-scraper.svg)](https://travis-ci.org/bb-ffbb/bbffbb-scraper)
 
-Scraper library for the <http://www.ffbb.com> site.
+Scraper library for the <http://www.ffbb.com> and <https://resultats.ffbb.com> site.
 
 ## Usage
 
@@ -45,7 +45,23 @@ miners.mineAssociation(searchTerm, function (err, data) {
     if(err) {
         console.error(err);
     } else {
-        console.log(licensees);
+        console.log(associations);
+    }
+});
+```
+
+### Mine associations list from commitee code
+
+```
+const miners = require('bbffbb-scraper').miners;
+
+let searchTerm = '7eb' // url id code of AIN comitee
+
+miners.mineAssociationsFromCommiteeCode(searchTerm, function (err, data) {
+    if(err) {
+        console.error(err);
+    } else {
+        console.log(associations);
     }
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbffbb-scraper",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "ffbb.com scraper library",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "assert": "^1.3.0",
+    "node-html-parser": "^5.1.0",
     "request": "^2.65.0"
   },
   "devDependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,8 @@ exports.urls = {
   base: 'http://www.ffbb.com',
   licenseSearchForm: 'http://www.ffbb.com/jouer/recherche-avancee',
   licenseSearchService: 'http://www.ffbb.com/system/ajax',
-  clubSearchService: 'http://www.ffbb.com/ffbb-webservice/lookup-club?cd_lbclub='
+  clubSearchService: 'http://www.ffbb.com/ffbb-webservice/lookup-club?cd_lbclub=',
+  clubListFromCommiteeService: 'https://resultats.ffbb.com/organisation/listeorganismes/',
 };
 
 exports.licenseSearchFormFields = {
@@ -45,4 +46,13 @@ exports.associationFields = {
   salleOrg: "Salle principale de l'association",
   urlWebSite: "Site internet",
   membres: "Membres"
+}
+
+exports.associationFromCommiteeFields = {
+  postalCode: 'Code postal',
+  clubNumber: 'Code organisation',
+  clubName: 'Nom organisation',
+  urlId: 'Url id organisation',
+  city: 'Ville',
+  type: 'Type organisation'
 }

--- a/src/miners.js
+++ b/src/miners.js
@@ -67,7 +67,7 @@ exports.mineLicense = function (query, next) {
 };
 
 /**
-   Asynchronously fetches associations, and passes the extracted data down to the
+   Asynchronously fetches associations from name, and passes the extracted data down to the
    callback.
 */
 exports.mineAssociation = function (query, next) {
@@ -85,3 +85,23 @@ exports.mineAssociation = function (query, next) {
     }
   });
 };
+
+/**
+   Asynchronously fetches associations from commitee url code, and passes the extracted data down to the
+   callback.
+*/
+exports.mineAssociationsFromCommiteeCode = function (code, next) {
+  req(urls.clubListFromCommiteeService + code + '.html', function (error, res, body) {
+    if (error) {
+      next(error);
+    } else if (res.statusCode !== 200) {
+      next(new Error('Wrong URL: ' + urls.clubSearchService + query), res);
+    } else {
+      try {
+        next(null, parsers.parseClubComiteeList(body));
+      } catch(e) {
+        next(e);
+      }
+    }
+  });
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var miners = require('../').miners;
 var licenseFields = require('../').constants.licenseFields;
 var associationFields = require('../').constants.associationFields;
+var associationFromCommiteeFields = require('../').constants.associationFromCommiteeFields;
 
 miners.mineLicense({
   firstName: '*',
@@ -23,3 +24,14 @@ miners.mineAssociation("ASVEL", function (err, data) {
     assert(f in data[0], 'ASVEL missing field \'' + associationFields[f] + '\'');
   }
 });
+
+// 7eb : AIN department code
+miners.mineAssociationsFromCommiteeCode("7eb", function (err, data) {
+  assert(err === null, 'Got an error: ' + err);
+  assert(data, 'AIN department code is not exist does not exist');
+  for (var f in associationFromCommiteeFields) {
+    assert(f in data[0], 'AIN missing field \'' + associationFromCommiteeFields[f] + '\'');
+  }
+});
+
+


### PR DESCRIPTION
Add a method returning list of organizations from committee code.
Use the result from web page `https://resultats.ffbb.com/organisation/listeorganismes/<CODE>.html`

Example : [organisations from AIN committee](https://resultats.ffbb.com/organisation/listeorganismes/7eb.html)

Use of node-html-parser dependency to help parse HTML from URL more easily